### PR TITLE
Change compression and bin location

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,19 +9,20 @@ description: |
 
 grade: stable
 confinement: strict
+compression: lzo
 
 apps:
   penguin-subtitle-player:
     extensions:
       - kde-neon
-    command: bin/PenguinSubtitlePlayer
+    command: usr/local/bin/PenguinSubtitlePlayer
     plugs: [home]
     
 parts:
   penguin-subtitle-player:
     source: https://github.com/carsonip/Penguin-Subtitle-Player.git
     options:
-     - "target.path=/bin"
+     - "target.path=/usr/local/bin"
      - "INSTALLS+=target"
     plugin: qmake
     project-files: [PenguinSubtitlePlayer.pro]


### PR DESCRIPTION
Change compression format to lzo for 2x startup speed, as seen in this [blogpost](https://snapcraft.io/blog/snap-speed-improvements-with-new-compression-algorithm).
I've tested it myself and on my (slow) machine it improved the cold start time from 14 seconds to 7, which is kind of impressive.

Also change bin location in the snap because the build command complained about it and changed it every time. So this suppresses the warning message.